### PR TITLE
Fix compilation errors

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,7 @@ MySQLfs is a FUSE filesystem driver which stores files in a MySQL database.
   - mysql-client libraries 5.0 or later
   - mysql-server 5.0 or later
   - fuse 2.5 or later
+  - autotools 
 
 * Build
 

--- a/config.h
+++ b/config.h
@@ -1,0 +1,89 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.in by autoheader.  */
+
+/* Fuse API Version */
+#define FUSE_USE_VERSION 25
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <fuse/fuse.h> header file. */
+#define HAVE_FUSE_FUSE_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <mysql.h> header file. */
+#define HAVE_MYSQL_H 1
+
+/* Define to 1 if you have the <mysql/mysql.h> header file. */
+/* #undef HAVE_MYSQL_MYSQL_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/mount.h> header file. */
+#define HAVE_SYS_MOUNT_H 1
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Minimal supported MySQL version */
+#define MYSQL_MIN_VERSION 50000
+
+/* Name of package */
+#define PACKAGE "mysqlfs"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "mysqlfs"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "mysqlfs 0.4.0"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "mysqlfs"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "0.4.0"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "0.4.0"
+
+/* Use 64 bits file offsets */
+#define _FILE_OFFSET_BITS 64

--- a/mysqlfs.c
+++ b/mysqlfs.c
@@ -102,7 +102,7 @@ static int mysqlfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
     ret = query_readdir(dbconn, inode, buf, filler);
     pool_put(dbconn);
 
-    return 0;
+    return ret;
 }
 
 /** FUSE function for mknod(const char *pathname, mode_t mode, dev_t dev); API call.  @see http://linux.die.net/man/2/mknod */

--- a/query.c
+++ b/query.c
@@ -295,7 +295,7 @@ int query_truncate(MYSQL *mysql, const char *path, off_t length)
 
     snprintf(sql, SQL_MAX,
              "UPDATE inodes SET size=%lld WHERE inode=%ld",
-             length, inode);
+             (long long)length, inode);
     log_printf(LOG_D_SQL, "sql=%s\n", sql);
     if ((ret = mysql_query(mysql, sql))) goto err_out;
 
@@ -788,16 +788,15 @@ static int write_one_block(MYSQL *mysql, long inode,
 		 "WHERE inode=%ld AND seq=%lu",
 		 inode, seq);
     } else {
-        size_t pos, new_size;
+        size_t pos;
         pos = snprintf(sql, sizeof(sql),
 		 "UPDATE data_blocks SET data=CONCAT(");
 	if (offset > 0)
-	    pos += snprintf(sql + pos, sizeof(sql) - pos, "RPAD(IF(ISNULL(data),'', data), %llu, '\\0'),", offset);
+	    pos += snprintf(sql + pos, sizeof(sql) - pos, "RPAD(IF(ISNULL(data),'', data), %llu, '\\0'),", (long long)offset);
 	pos += snprintf(sql + pos, sizeof(sql) - pos, "?,");
-	new_size = offset + size;
+
 	if (offset + size < current_block_size) {
-	    pos += snprintf(sql + pos, sizeof(sql) - pos, "SUBSTRING(data FROM %llu),", offset + size + 1);
-	    new_size = current_block_size;
+	    pos += snprintf(sql + pos, sizeof(sql) - pos, "SUBSTRING(data FROM %llu),", (long long)offset + size + 1);
 	}
 	sql[--pos] = '\0';	/* Remove the trailing comma. */
 	pos += snprintf(sql + pos, sizeof(sql) - pos, ") WHERE inode=%ld AND seq=%lu",
@@ -1217,7 +1216,6 @@ int query_fsck(MYSQL *mysql)
     // 1. delete inodes with deleted==1
     int ret;
 //    int ret2;
-    int result;
     char sql[SQL_MAX];
     printf("Stage 1...\n");
     snprintf(sql, SQL_MAX,
@@ -1295,7 +1293,7 @@ int query_fsck(MYSQL *mysql)
                      
       snprintf(sql, SQL_MAX, "update inodes set size=%ld where inode=%ld;", size, inode);
       log_printf(LOG_D_SQL, "sql=%s\n", sql);
-      result = mysql_query(mysql, sql);
+      mysql_query(mysql, sql);
 
 /*      if (myresult) { // something has gone wrong.. delete datablocks...
 


### PR DESCRIPTION
Recent GCC complains about mismatches between printf format and args.  Fix them.
Also remove unused variables to prevent warnings.